### PR TITLE
Move CI to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@0.9.2
+        uses: gittools/actions/gitversion/setup@v0.9.2
 
       # Use the id to reference the GitVersion values in future steps.
       - name: GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@0.9.2
+        uses: gittools/actions/gitversion/execute@v0.9.2
 
       - run: |
           echo PNuGetVersionV2: ${{ steps.gitversion.outputs.nuGetVersion }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,12 @@ jobs:
     name: Build Job
     runs-on: macos-latest
     defaults:
-      working-directory: Source
+      run:
+        working-directory: Source
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: NuGet
         run: dotnet restore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,12 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.3
         with:
-          versionSpec: '5.2.4'
+          versionSpec: '5.3.4'
 
-      # Use the id to reference the GitVersion values in future steps.
-      - name: GitVersion
+      - name: Generate Version Info using GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.3
-        with:
-          updateAssemblyInfo: true
-          updateAssemblyInfoFilename: '**/AssemblyInfo.cs'
+          with: updateAssemblyInfo: true
       
       - name: Display GitVersion values
         run: |
@@ -65,9 +62,7 @@ jobs:
       - name: NuGet
         run: nuget restore
 
-      # Build debug so it builds the example program to make sure there are no
-      # compile issues.
-      - name: Debug Build
+      - name: Debug Build for Example Program
         run: msbuild /t:Rebuild /p:Configuration=Debug /p:Platform=iPhoneSimulator
 
       - name: Release Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Generate Version Info using GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.3
-          with: updateAssemblyInfo: true
+          with: 
+            updateAssemblyInfo: true
       
       - name: Display GitVersion values
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.2
+         with:
+          versionSpec: '5.2.x'
 
       # Use the id to reference the GitVersion values in future steps.
       - name: GitVersion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v0.9.3
         with: 
           updateAssemblyInfo: true
+          assemblyInfoFileName: 'Source\SaturdayMP.XPlugins.iOS.BEMCheckBox\Properties\AssemblyInfo.cs'
       
       - name: Display GitVersion values
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,11 @@ jobs:
 
       - name: Build
         run: msbuild /t:Rebuild /p:Configuration=Debug /p:Platform=iPhoneSimulator
+
+      - name: Create NuGet Package
+        run: nuget pack SaturdayMP.XPlugins.iOS.BEMCheckBox.nuspec -properties Configuration=Release -Version ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+
+      - name: Publish to MyGet
+        run: |
+          nuget setApiKey ${{ secret.MYGET_API_KEY }}
+          nuget push SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v0.9.3
         with: 
           updateAssemblyInfo: true
-          assemblyInfoFileName: 'Source\SaturdayMP.XPlugins.iOS.BEMCheckBox\Properties\AssemblyInfo.cs'
+          updateAssemblyInfoFilename: 'Source\SaturdayMP.XPlugins.iOS.BEMCheckBox\Properties\AssemblyInfo.cs'
       
       - name: Display GitVersion values
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,44 @@ jobs:
       - name: GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.2
-
+        with:
+          updateAssemblyInfo: true
+      
+      - name: Display GitVersion values
       - run: |
-          echo PNuGetVersionV2: ${{ steps.gitversion.outputs.nuGetVersion }}
+          echo "Major: ${{ steps.gitversion.outputs.major }}"
+          echo "Minor: ${{ steps.gitversion.outputs.minor }}"
+          echo "Patch: ${{ steps.gitversion.outputs.patch }}"
+          echo "PreReleaseTag: ${{ steps.gitversion.outputs.preReleaseTag }}"
+          echo "PreReleaseTagWithDash: ${{ steps.gitversion.outputs.preReleaseTagWithDash }}"
+          echo "PreReleaseLabel: ${{ steps.gitversion.outputs.preReleaseLabel }}"
+          echo "PreReleaseNumber: ${{ steps.gitversion.outputs.preReleaseNumber }}"
+          echo "WeightedPreReleaseNumber: ${{ steps.gitversion.outputs.weightedPreReleaseNumber }}"
+          echo "BuildMetaData: ${{ steps.gitversion.outputs.buildMetaData }}"
+          echo "BuildMetaDataPadded: ${{ steps.gitversion.outputs.buildMetaDataPadded }}"
+          echo "FullBuildMetaData: ${{ steps.gitversion.outputs.fullBuildMetaData }}"
+          echo "MajorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}"
+          echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
+          echo "LegacySemVer: ${{ steps.gitversion.outputs.legacySemVer }}"
+          echo "LegacySemVerPadded: ${{ steps.gitversion.outputs.legacySemVerPadded }}"
+          echo "AssemblySemVer: ${{ steps.gitversion.outputs.assemblySemVer }}"
+          echo "AssemblySemFileVer: ${{ steps.gitversion.outputs.assemblySemFileVer }}"
+          echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
+          echo "InformationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}"
+          echo "BranchName: ${{ steps.gitversion.outputs.branchName }}"
+          echo "Sha: ${{ steps.gitversion.outputs.sha }}"
+          echo "ShortSha: ${{ steps.gitversion.outputs.shortSha }}"
+          echo "NuGetVersionV2: ${{ steps.gitversion.outputs.nuGetVersionV2 }}"
+          echo "NuGetVersion: ${{ steps.gitversion.outputs.nuGetVersion }}"
+          echo "NuGetPreReleaseTagV2: ${{ steps.gitversion.outputs.nuGetPreReleaseTagV2 }}"
+          echo "NuGetPreReleaseTag: ${{ steps.gitversion.outputs.nuGetPreReleaseTag }}"
+          echo "VersionSourceSha: ${{ steps.gitversion.outputs.versionSourceSha }}"
+          echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.commitsSinceVersionSource }}"
+          echo "CommitsSinceVersionSourcePadded: ${{ steps.gitversion.outputs.commitsSinceVersionSourcePadded }}"
+          echo "CommitDate: ${{ steps.gitversion.outputs.commitDate }}"
+
+      - name: Update Assembly Info
+      - run: 
 
       - name: NuGet
         run: nuget restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.2
         with:
-          versionSpec: '5.2.x'
+          versionSpec: '5.2.4'
 
       # Use the id to reference the GitVersion values in future steps.
       - name: GitVersion
@@ -32,8 +32,13 @@ jobs:
       - name: NuGet
         run: nuget restore
 
-      - name: Build
+      # Build debug so it builds the example program to make sure there are no
+      # compile issues.
+      - name: Debug Build
         run: msbuild /t:Rebuild /p:Configuration=Debug /p:Platform=iPhoneSimulator
+
+      - name: Release Build
+        run: msbuild /t:Rebuild /p:Configuration=Release /p:Platform=iPhone
 
       - name: Create NuGet Package
         run: nuget pack SaturdayMP.XPlugins.iOS.BEMCheckBox.nuspec -properties Configuration=Release -Version ${{ steps.gitversion.outputs.nuGetVersionV2 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.2
+        uses: gittools/actions/gitversion/setup@v0.9.3
         with:
           versionSpec: '5.2.4'
 
       # Use the id to reference the GitVersion values in future steps.
       - name: GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.2
+        uses: gittools/actions/gitversion/execute@v0.9.3
         with:
-          updateAssemblyInfo: 'true'
+          updateAssemblyInfo: true
       
       - name: Display GitVersion values
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
         run: msbuild /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU"
 
       - name: Create NuGet Package
-        run: nuget pack SaturdayMP.XPlugins.iOS.BEMCheckBox.nuspec -properties Configuration=Release -Version ${{ steps.gitversion.outputs.FullSemVer }}
+        run: nuget pack SaturdayMP.XPlugins.iOS.BEMCheckBox.nuspec -properties Configuration=Release -Version ${{ steps.gitversion.outputs.nuGetVersionV2 }}
 
       - name: Publish to MyGet
         run: |
           nuget setApiKey ${{ secrets.MYGET_API_KEY }} -Source https://www.myget.org/F/saturdaymp/api/v3/index.json
-          nuget push Source/SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.FullSemVer }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json
+          nuget push SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v0.9.3
         with:
           updateAssemblyInfo: true
+          updateAssemblyInfoFilename: '**/AssemblyInfo.cs'
       
       - name: Display GitVersion values
         run: |
@@ -73,9 +74,9 @@ jobs:
         run: msbuild /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU"
 
       - name: Create NuGet Package
-        run: nuget pack SaturdayMP.XPlugins.iOS.BEMCheckBox.nuspec -properties Configuration=Release -Version ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+        run: nuget pack SaturdayMP.XPlugins.iOS.BEMCheckBox.nuspec -properties Configuration=Release -Version ${{ steps.gitversion.outputs.FullSemVer }}
 
       - name: Publish to MyGet
         run: |
           nuget setApiKey ${{ secrets.MYGET_API_KEY }} -Source https://www.myget.org/F/saturdaymp/api/v3/index.json
-          nuget push SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json
+          nuget push SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.FullSemVer }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Change to Source Directory
-        run: cd Source
+        run: |
+          cd Source
+          ls -la Source
 
       - name: NuGet
         run: dotnet restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,12 @@ jobs:
   build:
     name: Build Job
     runs-on: macos-latest
+    defaults:
+      working-directory: Source
+
     steps:
       - uses: actions/checkout@v2
-
-      - name: Change to Source Directory
-        run: |
-          cd Source
-          ls -la Source
-
+      
       - name: NuGet
         run: dotnet restore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,5 @@ jobs:
 
       - name: Publish to MyGet
         run: |
-          nuget setApiKey ${{ secret.MYGET_API_KEY }}
+          nuget setApiKey ${{ secrets.MYGET_API_KEY }}
           nuget push SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
 
       - name: Publish to MyGet
         run: |
-          nuget setApiKey ${{ secrets.MYGET_API_KEY }}
+          nuget setApiKey ${{ secrets.MYGET_API_KEY }} -Source https://www.myget.org/F/saturdaymp/api/v3/index.json
           nuget push SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.nuGetVersionV2 }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.2
         with:
-          updateAssemblyInfo: true
+          updateAssemblyInfo: 'true'
       
       - name: Display GitVersion values
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Generate Version Info using GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v0.9.3
-          with: 
-            updateAssemblyInfo: true
+        with: 
+          updateAssemblyInfo: true
       
       - name: Display GitVersion values
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: msbuild /t:Rebuild /p:Configuration=Debug /p:Platform=iPhoneSimulator
 
       - name: Release Build
-        run: msbuild /t:Rebuild /p:Configuration=Release /p:Platform=iPhone
+        run: msbuild /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU"
 
       - name: Create NuGet Package
         run: nuget pack SaturdayMP.XPlugins.iOS.BEMCheckBox.nuspec -properties Configuration=Release -Version ${{ steps.gitversion.outputs.nuGetVersionV2 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   build:
     name: Build Job
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,6 @@ jobs:
           echo "CommitsSinceVersionSourcePadded: ${{ steps.gitversion.outputs.commitsSinceVersionSourcePadded }}"
           echo "CommitDate: ${{ steps.gitversion.outputs.commitDate }}"
 
-      - name: Update Assembly Info
-      - run: 
-
       - name: NuGet
         run: nuget restore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on: [push]
+
+jobs:
+  build:
+    name: Build Job
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Change to Source Directory
+        run: cd Source
+
+      - name: NuGet
+        run: dotnet restore
+
+      - name: Build
+        run: msbuild /t:Rebuild /p:Configuration=Debug /p:Platform=iPhoneSimulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.2
-         with:
+        with:
           versionSpec: '5.2.x'
 
       # Use the id to reference the GitVersion values in future steps.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v0.9.3
         with: 
           updateAssemblyInfo: true
-          updateAssemblyInfoFilename: 'Source\SaturdayMP.XPlugins.iOS.BEMCheckBox\Properties\AssemblyInfo.cs'
+          updateAssemblyInfoFilename: 'Source/SaturdayMP.XPlugins.iOS.BEMCheckBox/Properties/AssemblyInfo.cs'
       
       - name: Display GitVersion values
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,4 @@ jobs:
       - name: Publish to MyGet
         run: |
           nuget setApiKey ${{ secrets.MYGET_API_KEY }} -Source https://www.myget.org/F/saturdaymp/api/v3/index.json
-          nuget push SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.FullSemVer }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json
+          nuget push Source/SaturdayMP.XPlugins.iOS.BEMCheckBox.${{ steps.gitversion.outputs.FullSemVer }}.nupkg -Source https://www.myget.org/F/saturdaymp/api/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           updateAssemblyInfo: true
       
       - name: Display GitVersion values
-      - run: |
+        run: |
           echo "Major: ${{ steps.gitversion.outputs.major }}"
           echo "Minor: ${{ steps.gitversion.outputs.minor }}"
           echo "Patch: ${{ steps.gitversion.outputs.patch }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,15 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.3
+        uses: gittools/actions/gitversion/setup@v0.9.9
         with:
-          versionSpec: '5.3.4'
+          versionSpec: '5.6.10'
 
       - name: Generate Version Info using GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.3
+        uses: gittools/actions/gitversion/execute@v0.9.9
         with: 
           updateAssemblyInfo: true
-          updateAssemblyInfoFilename: 'Source/SaturdayMP.XPlugins.iOS.BEMCheckBox/Properties/AssemblyInfo.cs'
       
       - name: Display GitVersion values
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: NuGet
-        run: dotnet restore
+        run: nuget restore
 
       - name: Build
         run: msbuild /t:Rebuild /p:Configuration=Debug /p:Platform=iPhoneSimulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,22 @@ jobs:
         working-directory: Source
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history for GitVersion
+        run: git fetch --prune --unshallow
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@0.9.2
+
+      # Use the id to reference the GitVersion values in future steps.
+      - name: GitVersion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@0.9.2
+
+      - run: |
+          echo PNuGetVersionV2: ${{ steps.gitversion.outputs.nuGetVersion }}
 
       - name: NuGet
         run: nuget restore

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,7 @@
 branches:
+  feature:
+    mode: ContinuousDeployment
+    tag: feature-{BranchName}
   master:
     mode: ContinuousDeployment
     tag: 'alpha'

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,18 +1,77 @@
+assembly-versioning-scheme: MajorMinorPatch
+assembly-file-versioning-scheme: MajorMinorPatch
+mode: ContinuousDelivery
+tag-prefix: '[vV]'
+continuous-delivery-fallback-tag: ci
+major-version-bump-message: '\+semver:\s?(breaking|major)'
+minor-version-bump-message: '\+semver:\s?(feature|minor)'
+patch-version-bump-message: '\+semver:\s?(fix|patch)'
+no-bump-message: '\+semver:\s?(none|skip)'
+legacy-semver-padding: 4
+build-metadata-padding: 4
+commits-since-version-source-padding: 4
+tag-pre-release-weight: 60000
+commit-message-incrementing: Enabled
 branches:
-  feature:
-    mode: ContinuousDeployment
-    tag: wip-{BranchName}
   master:
     mode: ContinuousDeployment
-    tag: 'alpha'
+    tag: alpha
     increment: Minor
     prevent-increment-of-merged-branch-version: false
     track-merge-target: true
+    regex: ^master$
+    source-branches: []
+    tracks-release-branches: true
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 0
   release:
     mode: ContinuousDelivery
-    tag: 'beta'
-    increment: Patch
+    tag: beta
+    increment: None
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false
+    regex: ^releases?[/-]
+    source-branches:
+    - master
+    - release
+    tracks-release-branches: false
+    is-release-branch: true
+    is-mainline: false
+    pre-release-weight: 30000
+  feature:
+    mode: ContinuousDelivery
+    tag: useBranchName
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    regex: ^features?[/-]
+    source-branches:
+    - master
+    - release
+    - feature
+    tracks-release-branches: false
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 30000
+  pull-request:
+    mode: ContinuousDelivery
+    tag: PullRequest
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    tag-number-pattern: '[/-](?<number>\d+)'
+    track-merge-target: false
+    regex: ^(pull|pull\-requests|pr)[/-]
+    source-branches:
+    - master
+    - release
+    - feature
+    tracks-release-branches: false
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 30000
 ignore:
   sha: []
+commit-date-format: yyyy-MM-dd
+merge-message-formats: {}
+update-build-number: true

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 branches:
   feature:
     mode: ContinuousDeployment
-    tag: feature-{BranchName}
+    tag: wip-{BranchName}
   master:
     mode: ContinuousDeployment
     tag: 'alpha'

--- a/Source/SaturdayMP.XPlugins.iOS.BEMCheckBox/Properties/AssemblyInfo.cs
+++ b/Source/SaturdayMP.XPlugins.iOS.BEMCheckBox/Properties/AssemblyInfo.cs
@@ -26,6 +26,8 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyInformationalVersion ("1.0.*")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.


### PR DESCRIPTION
Fixes #11.  The CI is builds everything and automatically pushes to [MyGet](https://www.myget.org/feed/saturdaymp/package/nuget/SaturdayMP.XPlugins.iOS.BEMCheckBox).  For now I'll just manually upload the packages to NuGet but could add it to the CI at a later date if needed.