### PR TITLE
Add release notes workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,66 @@
+name: Release Notes
+
+on:
+  push:
+    branches: [ master, release/* ]
+  pull_request:
+    branches: [ master, release/* ]
+
+jobs:
+  generate-release-notes:
+    name: Generate Release Notes
+    runs-on: macos-13
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required for Calculate Version step (e.g. GitVersion)
+
+      # Required by GitVersion
+      - name: Install .NET 6.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.10.2
+        with:
+          versionSpec: '5.12.0'
+
+      - name: GitVersion Config
+        uses: gittools/actions/gitversion/execute@v0.10.2
+        with:
+          useConfigFile: true
+          additionalArguments: '/showConfig'
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.10.2
+        with:
+          useConfigFile: true
+          additionalArguments: '/updateprojectfiles'
+
+      - name: Install GitReleaseManager
+        uses: gittools/actions/gitreleasemanager/setup@v0.10.2
+        with:
+          versionSpec: '0.13.0'
+
+      # If there are no closed issues generating the Github Release will fail because it raises an exception.
+      # Work around this by checking for success or no closed issue errors.
+      - name: Create Release ${{ steps.gitversion.outputs.majorMinorPatch }}
+        run: |
+          dotnet gitreleasemanager create --owner ${{ github.repository_owner }} --repository ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --milestone v${{ steps.gitversion.outputs.majorMinorPatch }} --logFilePath output.txt || true
+          cat output.txt | grep 'No closed issues have been found for milestone\|Drafted release is available at'
+
+      - name: 'Generate Change Log'
+        run: |
+          dotnet-gitreleasemanager export --token ${{ secrets.GITHUB_TOKEN }} -o '${{ github.repository_owner }}' -r '${{ github.event.repository.name }}' -f 'CHANGELOG.md'
+          git add --renormalize CHANGELOG.md
+          cat CHANGELOG.md
+
+      - name: 'Commit Change Log if it Changed'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Committing auto generated change log.
+          file_pattern: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+## 1.4.3 (Dec, 22, 2017)
+
+
+Exposed the didTapCheckBox event.
+
+For a full list of issues fixed see the [1.4.3 Milestone](https://github.com/saturdaymp/XPlugins.iOS.BEMCheckBox/milestone/2).
+## 1.4.2 (Dec, 4, 2017)
+
+
+Fixed an issue where publishing to the App Store with a project that included BEMCheckBox would raise a Bitcode error.
+
+For a full list of issues fixed see the [1.4.2 Milestone](https://github.com/saturdaymp/XPlugins.iOS.BEMCheckBox/milestone/1).
+## 1.4.1 (Aug, 2, 2017)
+
+
+Wraps [BEMCheckBox](https://github.com/Boris-Em/BEMCheckBox) version [1.4.1](https://github.com/Boris-Em/BEMCheckBox/releases/tag/1.4.1).

--- a/GitReleaseManager.yml
+++ b/GitReleaseManager.yml
@@ -1,0 +1,46 @@
+export:
+  include-created-date-in-title: true
+  created-date-string-format: MMM, d, yyyy
+
+issue-labels-include:
+  - breaking
+  - bug
+  - devops
+  - dependency
+  - documentation
+  - enhancement
+  - refactoring
+  - security
+
+issue-labels-alias:
+  - name: breaking
+    header: Breaking
+    plural: Breaking
+
+  - name: bug
+    header: Bug
+    plural: Bugs
+
+  - name: dependency
+    header: Dependency
+    plural: Dependencies
+
+  - name: devops
+    header: DevOps
+    plural: DevOps
+
+  - name: documentation
+    header: Documentation
+    plural: Documentation
+
+  - name: enhancement
+    header: Enhancement
+    plural: Enhancements
+
+  - name: refactoring
+    header: Refactoring
+    plural: Refactoring
+
+  - name: security
+    header: Security
+    plural: Security


### PR DESCRIPTION
Add a new workflow file, `release-notes.yml`, which sets up a job to generate release notes. The workflow is triggered on pushes and pull requests to the `master` branch or any branch starting with `release/`. It runs on macOS-13 and performs the following steps:

- Checks out the repository
- Installs .NET 6.0
- Installs GitVersion v5.12.0
- Configures GitVersion using a config file
- Determines the version based on the config file
- Installs GitReleaseManager v0.13.0
- Creates a GitHub release for the determined version, handling cases where there are no closed issues for the milestone
- Generates a change log using dotnet-gitreleasemanager export command
- Commits the change log if it has changed