### PR TITLE
Update minimum iOS version in NuGet Package to 12 instead of 16

### DIFF
--- a/Source/ExampleClient/ExampleClient.csproj
+++ b/Source/ExampleClient/ExampleClient.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0-ios</TargetFramework>
+        <TargetFramework>net6.0-ios12</TargetFramework>
         <OutputType>Exe</OutputType>
         <Nullable>enable</Nullable>
         <ImplicitUsings>true</ImplicitUsings>
-        <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/Source/SaturdayMP.XPlugins.iOS.BEMCheckBox/SaturdayMP.XPlugins.iOS.BEMCheckBox.csproj
+++ b/Source/SaturdayMP.XPlugins.iOS.BEMCheckBox/SaturdayMP.XPlugins.iOS.BEMCheckBox.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net6.0-ios12</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>


### PR DESCRIPTION
Update the target framework from `net6.0-ios`, which defaulted to `net6.0-ios16.1`, to `net6.0-ios12`.